### PR TITLE
Fix crash for non-ASCII characters

### DIFF
--- a/ntfy_lite/ntfy.py
+++ b/ntfy_lite/ntfy.py
@@ -53,7 +53,7 @@ class _DataManager:
             self._data = open(filepath, "rb")
         elif message is not None:
             self._data = message.encode(encoding="UTF-8", errors="replace").decode()
-            self._data = message.encode(encoding="latin-1", errors="replace").decode()
+            self._data = message.encode(encoding="latin-1", errors="replace").decode(encoding="latin-1")
 
     def __enter__(self) -> typing.Union[typing.IO, str]:
         return self._data

--- a/ntfy_lite/ntfy.py
+++ b/ntfy_lite/ntfy.py
@@ -52,7 +52,6 @@ class _DataManager:
         if filepath is not None:
             self._data = open(filepath, "rb")
         elif message is not None:
-            self._data = message.encode(encoding="UTF-8", errors="replace").decode()
             self._data = message.encode(encoding="latin-1", errors="replace").decode(encoding="latin-1")
 
     def __enter__(self) -> typing.Union[typing.IO, str]:

--- a/tests/test_ntfy_lite.py
+++ b/tests/test_ntfy_lite.py
@@ -135,6 +135,20 @@ def test_action_http_push(clear):
     ntfy.push(topic, title, message=message, actions=action, dry_run=True)
 
 
+def test_extended_ascii_push():
+    topic = "ntfy_lite_test"
+    title = "ntfy lite test extended ascii push"
+    message = "ntfy_extended_ascii_push message: (°_°)"
+    ntfy.push(topic, title, message=message, dry_run=True)
+
+
+def test_unicode_push():
+    topic = "ntfy_lite_test"
+    title = "ntfy lite test unicode push"
+    message = "ntfy unicode push message: 🐋💐🪂"
+    ntfy.push(topic, title, message=message, dry_run=True)
+
+
 @pytest.mark.parametrize("clear", [True, False])
 def test_actions_view_http_push(clear):
     topic = "ntfy_lite_test"


### PR DESCRIPTION
`_DataManager` throws a `UnicodeDecodeError` if the message contains a non-ASCII character that can be encoded with latin-1 encoding, e.g., `°`. The message is encoded with latin-1 and then decoded with `decode()`. The `decode()` function without arguments defaults to UTF-8 encoding, so the code attempts to UTF-8 decode a message encoded with latin-1, causing the exception. I fixed this problem by passing the correct encoding to `decode()`.

I further removed the UTF-8 encoding / decoding since the result is not used, and the latin-1 encoding / decoding is stricter anyway.